### PR TITLE
Added Roadmap link of DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Table of Contents
   - [Firewall, Gateway and appliances](#firewall-gateway-and-appliances)
   - [Mail](#mail)
   - [Version Control System "VCS"](#version-control-system-vcs)
-
+  - [Roadmap](#roadmap)
 ## Cloud Computing
 
 #### IaaS
@@ -334,3 +334,9 @@ out of the box.
 [ViewVC](http://www.viewvc.org/) ([`Opensource`](https://github.com/viewvc/viewvc/)) ViewVC is a browser interface for CVS and Subversion version control repositories. It generates templatized HTML to present navigable directory, revision, and change log listings.
 
 [WebSVN](http://www.websvn.info/) ([`Opensource`](http://websvn.tigris.org/)) WebSVN offers a view onto your subversion repositories. You can view the log of any file or directory and see a list of all the files changed, added or deleted in any given revision.
+
+## Roadmap
+
+### - [DevOps Roadmap](https://roadmap.sh/devops)
+
+


### PR DESCRIPTION
Hi Joubert,

I came across your repository [awesome-devops](https://github.com/joubertredrat/awesome-devops) and found it to be a valuable resource for DevOps enthusiasts.

While browsing through the repository, I noticed that it was missing links to any structured guides such as the famous ["DevOps Roadmap"](https://roadmap.sh/devops). I took the initiative to submit a ["Pull Request"](https://github.com/joubertredrat/awesome-devops/pull/77) adding it.

Thank you for your time and effort in maintaining this valuable resource :)

Best,
Mouaaz